### PR TITLE
"MRA incorrectly references sf2.zip

### DIFF
--- a/mra/CPS1/_alt/Street Fighter II'  Champion Edition -USA 920803-.mra
+++ b/mra/CPS1/_alt/Street Fighter II'  Champion Edition -USA 920803-.mra
@@ -25,7 +25,7 @@
     <year>1992</year>
     <manufacturer>Capcom</manufacturer>
     <rbf>jtcps1</rbf>
-    <rom index="0" zip="sf2.zip|sf2ceuc.zip" md5="none">
+    <rom index="0" zip="sf2ce.zip|sf2ceuc.zip" md5="1fa84822685237cb69ac006b7935ba1d">
         <!-- relative position of each ROM section in the file, discounting the header, in kilobytes -->
         <!-- Size of M68000 code 1536 kB -->
         <!-- Sound CPU size 64 kB -->


### PR DESCRIPTION
"MRA incorrectly references sf2.zip instead of sf2ce.zip as the parent ROM"