### PR TITLE
Replace main Bubble Bobble MRA with the Japan, Ver 0.1, english mode

### DIFF
--- a/mister/bubl/releases/Bubble Bobble (Japan, Ver 0.1).mra
+++ b/mister/bubl/releases/Bubble Bobble (Japan, Ver 0.1).mra
@@ -21,16 +21,16 @@
 
 <misterromdescription>
     <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
-    <name>Bubble Bobble (US, Ver 5.1)</name>
-    <setname>bublboblr</setname>
+    <name>Bubble Bobble (Japan, Ver 0.1)</name>
+    <setname>bublbobl</setname>
     <rbf>jtbubl</rbf>
-    <rom index="0" zip="bublboblr.zip|bublbobl.zip" type="merged" md5="None">
+    <rom index="0" zip="bublbobl.zip" type="merged" md5="None">
         <!-- maincpu - starts at 0x0 -->
         <interleave output="16">
-            <part name="a78-25.51" crc="2d901c9d" map="12"/>
+            <part name="a78-06-1.51" crc="567934b6" map="12"/>
         </interleave>
         <interleave output="16">
-            <part name="a78-24.52" crc="b7afedc4" map="12"/>
+            <part name="a78-05-1.52" crc="9f8ee242" map="12"/>
         </interleave>
         <part repeat="0x10000">FF</part>
         <!-- subcpu - starts at 0x28000 -->
@@ -79,10 +79,10 @@
     <rom index="1">
         <part>00</part>
     </rom>
-    <switches default="FF,FF" base="16">
+    <switches default="FD,FF" base="16">
         <!-- DSW0 -->
         <dip name="Flip Screen" bits="1" ids="On,Off"/>
-        <dip name="Mode" bits="0" ids="Test /Pause,Test,Game, English,Game, Japanese"/>
+        <dip name="Mode" bits="2,3" ids="Test /Pause,Test,Game, English,Game, Japanese"/>
         <dip name="Demo Sounds" bits="3" ids="Off,On"/>
         <dip name="Coin A" bits="4,5" ids="2/3,2/1,1/2,1/1"/>
         <dip name="Coin B" bits="6,7" ids="2/3,2/1,1/2,1/1"/>


### PR DESCRIPTION
The Bubble Bobble version that has been taken as main in the repo uses the ROMs from the Super Bubble Bobble version. This is an extended version with 2 modes. It's interesting but IMO the "main" MRA should be the classic game.
Examining the MAME ROMs used in each MRA, looks like the Japanese version 0.1 uses the original ROM. Also in MAME seems to be the default version.
I'm not sure if the USA 5.1 version in _alternatives would be a better option. It should be but when launching the game it feels the same as the Japanese 0.1.
So I've copied the Japanese 0.1 to the main folder, and changed the MRA DIP switch default to use English Language. Some Japanese texts are still shown but IMO this is a better version to play.

---

NOTE: Strangely, the "bubbles not appearing at start screen bug" does not occur in the SUPER mode of the currently default version. Maybe this can be a clue in order to solve it. You can check this by running the game and selecting SUPER mode in the menu that appears at start. The bubbles seem to be shown correctly.

