### PR TITLE
Update Saturday Night Slam Masters (World 930713).mra

### DIFF
--- a/mister/cps15/releases/Saturday Night Slam Masters (World 930713).mra
+++ b/mister/cps15/releases/Saturday Night Slam Masters (World 930713).mra
@@ -84,5 +84,5 @@
     <rom index="1">
         <part>00</part>
     </rom>
-    <buttons names="Punch,Jump,Action,-,-,-,Start,Coin,Pause" default="Y,X,B,A,L,R,Select,Start,-"/>
+    <buttons names="Attack,Jump,Pin,-,-,-,Start,Coin,Pause" default="Y,X,B,A,L,R,Start,Select,-"/>
 </misterromdescription>


### PR DESCRIPTION
Proposed button name changes based on information in the arcade service manual.

![slammast](https://user-images.githubusercontent.com/18260997/101987741-a140c880-3c5b-11eb-84ba-dd933ac197fd.png)
