### PR TITLE
Create Street Fighter 2 Mix (Ver 0.98c 201214)

### DIFF
--- a/mra/_alternatives/_Street Fighter II'  Champion Edition/Street Fighter 2 Mix (Ver 0.98c 201214)
+++ b/mra/_alternatives/_Street Fighter II'  Champion Edition/Street Fighter 2 Mix (Ver 0.98c 201214)
@@ -1,0 +1,100 @@
+<!-- JTCPS1 - FPGA compatible core of CAPCOM CPS hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2020. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of CAPCOM copyrighted material. This work can be used with legally
+              obtained ROM dumps of CAPCOM games or with homework software for
+              the CPS platform.
+
+-->
+
+<misterromdescription>
+    <about author="jotego" webpage="https://patreon.com/topapate"
+                           source ="https://github.com/jotego/jtcps1"
+                           twitter="@topapate"/>
+    <name>Street Fighter 2 Mix (Ver 0.98c 201214)</name>
+    <setname>sf2mix</setname>
+    <year>2020</year>
+    <manufacturer>ZERO800</manufacturer>
+    <rbf>jtcps1</rbf>
+    <rom index="0" zip="sf2mix.zip" md5="74b7fdb2726eedbf1ffb27a8b066e3b1">
+        <!-- relative position of each ROM section in the file, discounting the header, in kilobytes -->
+        <!-- Size of M68000 code 1536 kB -->
+        <!-- Sound CPU size 64 kB -->
+        <part>00 06 </part>
+        <!-- OKI samples size 256 kB -->
+        <part>40 06 </part>
+        <!-- Graphics size 6144 kB -->
+        <part>40 07 </part>
+        <part repeat="10">FF</part>
+        <!-- CPS-B config for sf2ce --> 
+        <part> 32 FF 00 02 04 06 26 28 2A 2C 2E 36 00 30 02 04 08 30 </part>
+        <!-- Mapper for  --> 
+        <part> 1F 40 C8 73 F7 </part>
+        <part> 09 </part>
+        <part repeat="24">FF</part>
+        <!-- maincpu -->
+        <interleave output="16">
+            <part name="s92e_23b.8f" crc="ed5d932f" map="21"/>
+        </interleave>
+        <interleave output="16">
+            <part name="s92_22b.7f" crc="27b92198" map="21"/>
+        </interleave>
+        <interleave output="16">
+            <part name="s92_21a.6f" crc="50cf4959" map="21"/>
+        </interleave>
+        <!-- audiocpu -->
+        <part name="s92_09.11a" crc="a379fdc5"/>
+        <!-- oki -->
+        <part name="s92_18.11c" crc="6aa5d7fa"/>
+        <part name="s92_19.12c" crc="f92f5a4f"/>
+        <!-- gfx -->
+        <interleave output="64">
+            <part name="s92-1m.3a" crc="a1d1a20f"  map="00000021"/>
+            <part name="s92-3m.5a" crc="0708bb01"  map="00002100"/>
+            <part name="s92-2m.4a" crc="42e159b9"  map="00210000"/>
+            <part name="s92-4m.6a" crc="cac353a3"  map="21000000"/>
+        </interleave>
+        <interleave output="64">
+            <part name="s92-5m.7a" crc="44788fc3"  map="00000021"/>
+            <part name="s92-7m.9a" crc="db3e33f9"  map="00002100"/>
+            <part name="s92-6m.8a" crc="7f757d22"  map="00210000"/>
+            <part name="s92-8m.10a" crc="7e2c6383"  map="21000000"/>
+        </interleave>
+        <interleave output="64">
+            <part name="s92-10m.3c" crc="d4e75239"  map="00000021"/>
+            <part name="s92-12m.5c" crc="c66dc52c"  map="00002100"/>
+            <part name="s92-11m.4c" crc="416149f2"  map="00210000"/>
+            <part name="s92-13m.6c" crc="7316d4bc"  map="21000000"/>
+        </interleave>
+    </rom>
+
+    <!-- Set bit 1 for vertical games.
+         Set bit 2 for games using 4-way joysticks -->
+    <rom index="1"><part> 00 </part></rom>
+
+    <buttons names="B0,B1,B2,B3,B4,B5,Start,Coin,Pause" 
+        default="A,B,X,Y,R,L,Select,Select,Start"/>
+    <switches page_id="1" page_name="Switches" default="FF,FF,FF" base="8">
+        <dip bits="0,2"	 name="Coin A" ids="4 Coins/1 Credit,3 Coins/1 Credit,2 Coins/1 Credit,1 Coin/6 Credits,1 Coin/4 Credits,1 Coin/3 Credits,1 Coin/2 Credits,1 Coin/1 Credit"/>
+        <dip bits="3,5"	 name="Coin B" ids="4 Coins/1 Credit,3 Coins/1 Credit,2 Coins/1 Credit,1 Coin/6 Credits,1 Coin/4 Credits,1 Coin/3 Credits,1 Coin/2 Credits,1 Coin/1 Credit"/>
+        <dip bits="6"	 name="2 to Start, 1 to Cont." ids="On,Off"/>
+        <dip bits="7"	 name="Portuguese Win Quotes" ids="On,Off"/>
+        <dip bits="8,10"	 name="Difficulty" ids="7 (Hardest),6,5,4,3 (Normal),2,1,0 (Easiest)"/>
+        <dip bits="11"	 name="Complete Mode" ids="On,Off"/>
+        <dip bits="18"	 name="Free Play" ids="On,Off"/>
+        <dip bits="19"	 name="Freeze" ids="On,Off"/>
+        <dip bits="20"	 name="Flip Screen" ids="On,Off"/>
+        <dip bits="21"	 name="Demo Sounds" ids="On,Off"/>
+        <dip bits="22"	 name="Continue" ids="Yes,No"/>
+        <dip bits="23"	 name="Game Mode" ids="Test,Game"/>
+    </switches>
+</misterromdescription>


### PR DESCRIPTION
This is a hack of Street Fighter II': Champion Edition. For more information about this hack go to https://sf2mix.github.io/. The hack is perfectly playable on jotego's core except for Complete Mode. The fake 3d backgrounds in Complete Mode are (currently) not supported by jotego's core. Therefore the default dip switch setting for Complete Mode is off.