### PR TITLE
Update MRA to support MegaMan 950925 USA Sample for MAME-GETTER script 

### DIFF
--- a/mra/CPS1/Mega Man  The Power Battle -CPS1, USA 951006-.mra
+++ b/mra/CPS1/Mega Man  The Power Battle -CPS1, USA 951006-.mra
@@ -21,7 +21,7 @@
                            source ="https://github.com/jotego/jtcps1"
                            twitter="@topapate"/>
     <name>Mega Man: The Power Battle (CPS1, USA 951006)</name>
-	<mameversion>0228</mameversion>
+	<mameversion>0229</mameversion>
     <setname>megaman</setname>
     <year>1995</year>
     <manufacturer>Capcom</manufacturer>

--- a/mra/CPS1/Mega Man  The Power Battle -CPS1, USA 951006-.mra
+++ b/mra/CPS1/Mega Man  The Power Battle -CPS1, USA 951006-.mra
@@ -21,7 +21,7 @@
                            source ="https://github.com/jotego/jtcps1"
                            twitter="@topapate"/>
     <name>Mega Man: The Power Battle (CPS1, USA 951006)</name>
-	<mameversion>0217</mameversion>
+	<mameversion>0229</mameversion>
     <setname>megaman</setname>
     <year>1995</year>
     <manufacturer>Capcom</manufacturer>

--- a/mra/CPS1/Mega Man  The Power Battle -CPS1, USA 951006-.mra
+++ b/mra/CPS1/Mega Man  The Power Battle -CPS1, USA 951006-.mra
@@ -21,7 +21,7 @@
                            source ="https://github.com/jotego/jtcps1"
                            twitter="@topapate"/>
     <name>Mega Man: The Power Battle (CPS1, USA 951006)</name>
-	<mameversion>0229</mameversion>
+	<mameversion>0228</mameversion>
     <setname>megaman</setname>
     <year>1995</year>
     <manufacturer>Capcom</manufacturer>

--- a/mra/_alternatives/_Mega Man  The Power Battle -CPS1/Mega Man  The Power Battle -CPS1, Asia 951006-.mra
+++ b/mra/_alternatives/_Mega Man  The Power Battle -CPS1/Mega Man  The Power Battle -CPS1, Asia 951006-.mra
@@ -21,7 +21,7 @@
                            source ="https://github.com/jotego/jtcps1"
                            twitter="@topapate"/>
     <name>Mega Man: The Power Battle (CPS1, Asia 951006)</name>
-    <mameversion>0217</mameversion>
+    <mameversion>0229</mameversion>
     <setname>megamana</setname>
     <year>1995</year>
     <manufacturer>Capcom</manufacturer>

--- a/mra/_alternatives/_Mega Man  The Power Battle -CPS1/Mega Man  The Power Battle -CPS1, USA 951006-.mra
+++ b/mra/_alternatives/_Mega Man  The Power Battle -CPS1/Mega Man  The Power Battle -CPS1, USA 951006-.mra
@@ -21,7 +21,7 @@
                            source ="https://github.com/jotego/jtcps1"
                            twitter="@topapate"/>
     <name>Mega Man: The Power Battle (CPS1, USA 951006)</name>
-	<mameversion>0217</mameversion>
+	<mameversion>0229</mameversion>
     <setname>megaman</setname>
     <year>1995</year>
     <manufacturer>Capcom</manufacturer>

--- a/mra/_alternatives/_Mega Man  The Power Battle -CPS1/Mega Man - CPS1.5.mra
+++ b/mra/_alternatives/_Mega Man  The Power Battle -CPS1/Mega Man - CPS1.5.mra
@@ -21,7 +21,7 @@
                            source ="https://github.com/jotego/jtcps1"
                            twitter="@topapate"/>
     <name>Mega Man: The Power Battle CPS 1.5</name>
-    <mameversion>0217</mameversion>
+    <mameversion>0229</mameversion>
     <setname>megaman</setname>
     <year>1995</year>
     <manufacturer>Capcom</manufacturer>

--- a/mra/_alternatives/_Mega Man  The Power Battle -CPS1/Rockman  The Power Battle -CPS1, Japan 950922-.mra
+++ b/mra/_alternatives/_Mega Man  The Power Battle -CPS1/Rockman  The Power Battle -CPS1, Japan 950922-.mra
@@ -21,7 +21,7 @@
                            source ="https://github.com/jotego/jtcps1"
                            twitter="@topapate"/>
     <name>Rockman: The Power Battle (CPS1, Japan 950922)</name>
-    <mameversion>0217</mameversion>
+    <mameversion>0229</mameversion>
     <setname>rockmanj</setname>
     <year>1995</year>
     <manufacturer>Capcom</manufacturer>


### PR DESCRIPTION
Changes mameversion to 0229 to support MegaMan 950925 USA Sample for MAME-GETTER script. 

MAME-GETTER script pull megaman.zip rom for the first MRA it finds the rom listed in. Once the rom is downloaded additional MRA using the same rom file are skipped. 

   