### PR TITLE
Update Street Fighter II'  Hyper Fighting -USA 921209-.mra

### DIFF
--- a/mra/_alternatives/_Street Fighter II'  Hyper Fighting/Street Fighter II'  Hyper Fighting -USA 921209-.mra
+++ b/mra/_alternatives/_Street Fighter II'  Hyper Fighting/Street Fighter II'  Hyper Fighting -USA 921209-.mra
@@ -26,7 +26,7 @@
     <year>1992</year>
     <manufacturer>Capcom</manufacturer>
     <rbf>jtcps1</rbf>
-    <rom index="0" zip="sf2.zip|sf2hfu.zip" md5="none">
+    <rom index="0" zip="sf2hf.zip|sf2hfu.zip" md5="none">
         <!-- relative position of each ROM section in the file, discounting the header, in kilobytes -->
         <!-- Size of M68000 code 1536 kB -->
         <!-- Sound CPU size 64 kB -->


### PR DESCRIPTION
Existing SF2 Hyper Fighting USA MRA doesn't load rom.  It references SF2.zip instead of the SF2HF.zip merged rom.