### PR TITLE
Add Legendary Wings Alternatives

### DIFF
--- a/mra/_alternatives/_Legendary Wings/Ares no Tsubasa (Japan).mra
+++ b/mra/_alternatives/_Legendary Wings/Ares no Tsubasa (Japan).mra
@@ -1,0 +1,67 @@
+<misterromdescription>
+    <name>Ares no Tsubasa (Japan)</name>
+    <setname>lwings</setname>
+    <year>1986</year>
+    <manufacturer>Capcom</manufacturer>
+    <category>Shooter</category>
+    <mameversion>0217</mameversion>
+    <rbf alt="jtsz">jtsectionz</rbf>
+    <rom index="0" zip="lwings.zip" md5="none">
+        <!-- 32-byte Header -->
+        <part> 01 00 00 00 00 00 00 00 </part>
+        <part> 01 80 02 00 02 40 06 40 </part>
+        <part> 08 40 FF FF FF FF FF FF </part>
+        <part> FF FF FF FF FF FF FF FF </part>
+        <!-- ROMs -->
+        
+        <!-- CPU: banks -->
+        <part name="a_07c.rom" crc="d6a2edc4"/> 
+        <part name="9c_lw03.bin" crc="ec5cc201"/>
+        <!-- CPU: non banked -->
+        <part name="a_06c.rom" crc="2068a738"/>
+
+        <!-- Sound -->
+        <part name="11e_lw04.bin" crc="a20337a2"/>
+        <!-- CHAR -->
+        <part name="9h_lw05.bin" crc="091d923c"/>
+        <!-- SCROLL -->
+        <interleave output="32">
+            <part name="b_03f.rom" crc="9b374dcc" map="0001"/>
+            <part name="b_03b.rom" crc="4f8182e9" map="0010"/>
+            <part name="b_03d.rom" crc="001caa35" map="0100"/>
+            <part name="b_03e.rom" crc="176e3027" map="1000"/>
+        </interleave>
+        <interleave output="32">
+            <part name="b_01f.rom" crc="23654e0a" map="0001"/>
+            <part name="b_01b.rom" crc="f1617374" map="0010"/>
+            <part name="b_01d.rom" crc="0ba008c3" map="0100"/>
+            <part name="b_01e.rom" crc="f5d25623" map="1000"/>
+        </interleave>
+        <!-- OBJ -->
+        <interleave output="16">
+            <part name="b_03j.rom" crc="8f3c763a" map="01"/>
+            <part name="b_03h.rom" crc="7d58f532" map="10"/>
+        </interleave>
+        <interleave output="16">
+            <part name="b_01j.rom" crc="7cc90a1d" map="01"/>
+            <part name="b_01h.rom" crc="3e396eda" map="10"/>
+        </interleave>
+    </rom>
+    <!-- enable vertical screen -->
+    <rom index="1"><part> 01 </part></rom>
+    <switches page_id="1" page_name="Switches" base="0x10" default="FF,FD">
+        <!-- DSWA -->
+        <dip name="Test mode" bits="0" ids="On,Off"></dip>
+        <dip name="Flip Screen" bits="1" ids="On,Off"></dip>
+        <dip name="Lives" bits="2,3" ids="6,4,5,3"></dip>
+        <dip name="Coin B" bits="4,5" ids="4/1,2/1,3/1,1/1"></dip>
+        <dip name="Coin A" bits="6,7" ids="2/4,1/2,1/3,1/1"></dip>
+        <!-- DSWB -->
+        <dip name="Continue play" bits="8" ids="Off,On"></dip>
+        <dip name="Level" bits="9,10" ids="Hardest,Easy,Hard,Medium"></dip>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"></dip>
+        <dip name="Allow Continue" bits="12" ids="No,Yes"></dip>
+        <dip name="Bonus Life" bits="13,15" ids="None,30k/60k,30k/80k,20k/60k,40k/10k0,20k/70k,30k/70k,20k/50k"></dip>
+    </switches>
+    <buttons names="Shot,Bomb,Start,Coin,Pause" default="A,B,R,L,Start"/>
+</misterromdescription>

--- a/mra/_alternatives/_Legendary Wings/Ares no Tsubasa (Japan).mra
+++ b/mra/_alternatives/_Legendary Wings/Ares no Tsubasa (Japan).mra
@@ -1,12 +1,12 @@
 <misterromdescription>
     <name>Ares no Tsubasa (Japan)</name>
-    <setname>lwings</setname>
+    <setname>lwingsj</setname>
     <year>1986</year>
     <manufacturer>Capcom</manufacturer>
     <category>Shooter</category>
     <mameversion>0217</mameversion>
     <rbf alt="jtsz">jtsectionz</rbf>
-    <rom index="0" zip="lwings.zip" md5="none">
+    <rom index="0" zip="lwings.zip|lwingsj.zip" type="merged|nonmerged|split" md5="none">
         <!-- 32-byte Header -->
         <part> 01 00 00 00 00 00 00 00 </part>
         <part> 01 80 02 00 02 40 06 40 </part>

--- a/mra/_alternatives/_Legendary Wings/Ares no Tsubasa (Japan, rev. A).mra
+++ b/mra/_alternatives/_Legendary Wings/Ares no Tsubasa (Japan, rev. A).mra
@@ -1,0 +1,67 @@
+<misterromdescription>
+    <name>Ares no Tsubasa (Japan, Rev A)</name>
+    <setname>lwings</setname>
+    <year>1986</year>
+    <manufacturer>Capcom</manufacturer>
+    <category>Shooter</category>
+    <mameversion>0217</mameversion>
+    <rbf alt="jtsz">jtsectionz</rbf>
+    <rom index="0" zip="lwings.zip" md5="none">
+        <!-- 32-byte Header -->
+        <part> 01 00 00 00 00 00 00 00 </part>
+        <part> 01 80 02 00 02 40 06 40 </part>
+        <part> 08 40 FF FF FF FF FF FF </part>
+        <part> FF FF FF FF FF FF FF FF </part>
+        <!-- ROMs -->
+        
+        <!-- CPU: banks -->
+        <part name="at_02.7c" crc="d6a2edc4"/> 
+        <part name="at_03.9c" crc="ec5cc201"/>
+        <!-- CPU: non banked -->
+        <part name="at_01a.6c" crc="568f1ea5"/>
+
+        <!-- Sound -->
+        <part name="at_03.11e" crc="a20337a2"/>
+        <!-- CHAR -->
+        <part name="at_05.9h" crc="091d923c"/>
+        <!-- SCROLL -->
+        <interleave output="32">
+            <part name="at_15.3f" crc="9b374dcc" map="0001"/>
+            <part name="at_12.3b" crc="4f8182e9" map="0010"/>
+            <part name="at_13.3d" crc="001caa35" map="0100"/>
+            <part name="at_14.3e" crc="176e3027" map="1000"/>
+        </interleave>
+        <interleave output="32">
+            <part name="at_09.1f" crc="23654e0a" map="0001"/>
+            <part name="at_06.1b" crc="f1617374" map="0010"/>
+            <part name="at_07.1d" crc="0ba008c3" map="0100"/>
+            <part name="at_08.1e" crc="f5d25623" map="1000"/>
+        </interleave>
+        <!-- OBJ -->
+        <interleave output="16">
+            <part name="at_17.3j" crc="8f3c763a" map="01"/>
+            <part name="at_16.3h" crc="7d58f532" map="10"/>
+        </interleave>
+        <interleave output="16">
+            <part name="at_11.1j" crc="7cc90a1d" map="01"/>
+            <part name="at_10.1h" crc="3e396eda" map="10"/>
+        </interleave>
+    </rom>
+    <!-- enable vertical screen -->
+    <rom index="1"><part> 01 </part></rom>
+    <switches page_id="1" page_name="Switches" base="0x10" default="FF,FD">
+        <!-- DSWA -->
+        <dip name="Test mode" bits="0" ids="On,Off"></dip>
+        <dip name="Flip Screen" bits="1" ids="On,Off"></dip>
+        <dip name="Lives" bits="2,3" ids="6,4,5,3"></dip>
+        <dip name="Coin B" bits="4,5" ids="4/1,2/1,3/1,1/1"></dip>
+        <dip name="Coin A" bits="6,7" ids="2/4,1/2,1/3,1/1"></dip>
+        <!-- DSWB -->
+        <dip name="Continue play" bits="8" ids="Off,On"></dip>
+        <dip name="Level" bits="9,10" ids="Hardest,Easy,Hard,Medium"></dip>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"></dip>
+        <dip name="Allow Continue" bits="12" ids="No,Yes"></dip>
+        <dip name="Bonus Life" bits="13,15" ids="None,30k/60k,30k/80k,20k/60k,40k/10k0,20k/70k,30k/70k,20k/50k"></dip>
+    </switches>
+    <buttons names="Shot,Bomb,Start,Coin,Pause" default="A,B,R,L,Start"/>
+</misterromdescription>

--- a/mra/_alternatives/_Legendary Wings/Ares no Tsubasa (Japan, rev. A).mra
+++ b/mra/_alternatives/_Legendary Wings/Ares no Tsubasa (Japan, rev. A).mra
@@ -1,12 +1,12 @@
 <misterromdescription>
     <name>Ares no Tsubasa (Japan, Rev A)</name>
-    <setname>lwings</setname>
+    <setname>lwingsja</setname>
     <year>1986</year>
     <manufacturer>Capcom</manufacturer>
     <category>Shooter</category>
     <mameversion>0217</mameversion>
     <rbf alt="jtsz">jtsectionz</rbf>
-    <rom index="0" zip="lwings.zip" md5="none">
+    <rom index="0" zip="lwings.zip|lwingsja.zip" type="merged|nonmerged|split" md5="none">
         <!-- 32-byte Header -->
         <part> 01 00 00 00 00 00 00 00 </part>
         <part> 01 80 02 00 02 40 06 40 </part>

--- a/mra/_alternatives/_Legendary Wings/Legendary Wings (US set 2).mra
+++ b/mra/_alternatives/_Legendary Wings/Legendary Wings (US set 2).mra
@@ -1,0 +1,67 @@
+<misterromdescription>
+    <name>Legendary Wings (US set 2)</name>
+    <setname>lwings</setname>
+    <year>1986</year>
+    <manufacturer>Capcom</manufacturer>
+    <category>Shooter</category>
+    <mameversion>0217</mameversion>
+    <rbf alt="jtsz">jtsectionz</rbf>
+    <rom index="0" zip="lwings.zip" md5="none">
+        <!-- 32-byte Header -->
+        <part> 01 00 00 00 00 00 00 00 </part>
+        <part> 01 80 02 00 02 40 06 40 </part>
+        <part> 08 40 FF FF FF FF FF FF </part>
+        <part> FF FF FF FF FF FF FF FF </part>
+        <!-- ROMs -->
+        
+        <!-- CPU: banks -->
+        <part name="u14-k" crc="5d91c828"/>
+        <part name="9c_lw03.bin" crc="ec5cc201"/>
+        <!-- CPU: non banked -->
+        <part name="u13-l" crc="3069c01c"/>
+
+        <!-- Sound -->
+        <part name="11e_lw04.bin" crc="a20337a2"/>
+        <!-- CHAR -->
+        <part name="9h_lw05.bin" crc="091d923c"/>
+        <!-- SCROLL -->
+        <interleave output="32">
+            <part name="b_03f.rom" crc="9b374dcc" map="0001"/>
+            <part name="b_03b.rom" crc="4f8182e9" map="0010"/>
+            <part name="b_03d.rom" crc="001caa35" map="0100"/>
+            <part name="b_03e.rom" crc="176e3027" map="1000"/>
+        </interleave>
+        <interleave output="32">
+            <part name="b_01f.rom" crc="23654e0a" map="0001"/>
+            <part name="b_01b.rom" crc="f1617374" map="0010"/>
+            <part name="b_01d.rom" crc="0ba008c3" map="0100"/>
+            <part name="b_01e.rom" crc="f5d25623" map="1000"/>
+        </interleave>
+        <!-- OBJ -->
+        <interleave output="16">
+            <part name="b_03j.rom" crc="8f3c763a" map="01"/>
+            <part name="b_03h.rom" crc="7d58f532" map="10"/>
+        </interleave>
+        <interleave output="16">
+            <part name="b_01j.rom" crc="7cc90a1d" map="01"/>
+            <part name="b_01h.rom" crc="3e396eda" map="10"/>
+        </interleave>
+    </rom>
+    <!-- enable vertical screen -->
+    <rom index="1"><part> 01 </part></rom>
+    <switches page_id="1" page_name="Switches" base="0x10" default="FF,FD">
+        <!-- DSWA -->
+        <dip name="Test mode" bits="0" ids="On,Off"></dip>
+        <dip name="Flip Screen" bits="1" ids="On,Off"></dip>
+        <dip name="Lives" bits="2,3" ids="6,4,5,3"></dip>
+        <dip name="Coin B" bits="4,5" ids="4/1,2/1,3/1,1/1"></dip>
+        <dip name="Coin A" bits="6,7" ids="2/4,1/2,1/3,1/1"></dip>
+        <!-- DSWB -->
+        <dip name="Continue play" bits="8" ids="Off,On"></dip>
+        <dip name="Level" bits="9,10" ids="Hardest,Easy,Hard,Medium"></dip>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"></dip>
+        <dip name="Allow Continue" bits="12" ids="No,Yes"></dip>
+        <dip name="Bonus Life" bits="13,15" ids="None,30k/60k,30k/80k,20k/60k,40k/10k0,20k/70k,30k/70k,20k/50k"></dip>
+    </switches>
+    <buttons names="Shot,Bomb,Start,Coin,Pause" default="A,B,R,L,Start"/>
+</misterromdescription>

--- a/mra/_alternatives/_Legendary Wings/Legendary Wings (US set 2).mra
+++ b/mra/_alternatives/_Legendary Wings/Legendary Wings (US set 2).mra
@@ -1,12 +1,12 @@
 <misterromdescription>
     <name>Legendary Wings (US set 2)</name>
-    <setname>lwings</setname>
+    <setname>lwings2</setname>
     <year>1986</year>
     <manufacturer>Capcom</manufacturer>
     <category>Shooter</category>
     <mameversion>0217</mameversion>
     <rbf alt="jtsz">jtsectionz</rbf>
-    <rom index="0" zip="lwings.zip" md5="none">
+    <rom index="0" zip="lwings.zip|lwings2.zip" type="merged|nonmerged|split" md5="none">
         <!-- 32-byte Header -->
         <part> 01 00 00 00 00 00 00 00 </part>
         <part> 01 80 02 00 02 40 06 40 </part>

--- a/mra/_alternatives/_Legendary Wings/Legendary Wings (bootleg).mra
+++ b/mra/_alternatives/_Legendary Wings/Legendary Wings (bootleg).mra
@@ -1,12 +1,12 @@
 <misterromdescription>
     <name>Legendary Wings (bootleg)</name>
-    <setname>lwings</setname>
+    <setname>lwingsb</setname>
     <year>1986</year>
     <manufacturer>Capcom</manufacturer>
     <category>Shooter</category>
     <mameversion>0217</mameversion>
     <rbf alt="jtsz">jtsectionz</rbf>
-    <rom index="0" zip="lwings.zip" md5="none">
+    <rom index="0" zip="lwings.zip|lwingsb.zip" type="merged|nonmerged|split" md5="none">
         <!-- 32-byte Header -->
         <part> 01 00 00 00 00 00 00 00 </part>
         <part> 01 80 02 00 02 40 06 40 </part>

--- a/mra/_alternatives/_Legendary Wings/Legendary Wings (bootleg).mra
+++ b/mra/_alternatives/_Legendary Wings/Legendary Wings (bootleg).mra
@@ -1,0 +1,67 @@
+<misterromdescription>
+    <name>Legendary Wings (bootleg)</name>
+    <setname>lwings</setname>
+    <year>1986</year>
+    <manufacturer>Capcom</manufacturer>
+    <category>Shooter</category>
+    <mameversion>0217</mameversion>
+    <rbf alt="jtsz">jtsectionz</rbf>
+    <rom index="0" zip="lwings.zip" md5="none">
+        <!-- 32-byte Header -->
+        <part> 01 00 00 00 00 00 00 00 </part>
+        <part> 01 80 02 00 02 40 06 40 </part>
+        <part> 08 40 FF FF FF FF FF FF </part>
+        <part> FF FF FF FF FF FF FF FF </part>
+        <!-- ROMs -->
+        
+        <!-- CPU: banks -->
+        <part name="ic18.bin" crc="2a00cde8"/>
+        <part name="ic19.bin" crc="ec5cc201"/>
+        <!-- CPU: non banked -->
+        <part name="ic17.bin" crc="fe8a8823"/>
+
+        <!-- Sound -->
+        <part name="ic37.bin" crc="a20337a2"/>
+        <!-- CHAR -->
+        <part name="ic60.bin" crc="091d923c"/>
+        <!-- SCROLL -->
+        <interleave output="32">
+            <part name="ic63.bin" crc="99e134ba" map="0001"/>
+            <part name="ic2.bin" crc="32e17b3c" map="0010"/>
+            <part name="ic26.bin" crc="fdd1908a" map="0100"/>
+            <part name="ic50.bin" crc="5436392c" map="1000"/>
+        </interleave>
+        <interleave output="32">
+            <part name="ic62.bin" crc="c8f28777" map="0001"/>
+            <part name="ic1.bin" crc="52e533c1" map="0010"/>
+            <part name="ic25.bin" crc="5c73d406" map="0100"/>
+            <part name="ic49.bin" crc="ffdbdd69" map="1000"/>
+        </interleave>
+        <!-- OBJ -->
+        <interleave output="16">
+            <part name="ic99.bin" crc="163946da" map="01"/>
+            <part name="ic87.bin" crc="bca275ac" map="10"/>
+        </interleave>
+        <interleave output="16">
+            <part name="ic98.bin" crc="7cc90a1d" map="01"/>
+            <part name="ic86.bin" crc="3e396eda" map="10"/>
+        </interleave>
+    </rom>
+    <!-- enable vertical screen -->
+    <rom index="1"><part> 01 </part></rom>
+    <switches page_id="1" page_name="Switches" base="0x10" default="FF,FD">
+        <!-- DSWA -->
+        <dip name="Test mode" bits="0" ids="On,Off"></dip>
+        <dip name="Flip Screen" bits="1" ids="On,Off"></dip>
+        <dip name="Lives" bits="2,3" ids="6,4,5,3"></dip>
+        <dip name="Coin B" bits="4,5" ids="4/1,2/1,3/1,1/1"></dip>
+        <dip name="Coin A" bits="6,7" ids="2/4,1/2,1/3,1/1"></dip>
+        <!-- DSWB -->
+        <dip name="Continue play" bits="8" ids="Off,On"></dip>
+        <dip name="Level" bits="9,10" ids="Hardest,Easy,Hard,Medium"></dip>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"></dip>
+        <dip name="Allow Continue" bits="12" ids="No,Yes"></dip>
+        <dip name="Bonus Life" bits="13,15" ids="None,30k/60k,30k/80k,20k/60k,40k/10k0,20k/70k,30k/70k,20k/50k"></dip>
+    </switches>
+    <buttons names="Shot,Bomb,Start,Coin,Pause" default="A,B,R,L,Start"/>
+</misterromdescription>


### PR DESCRIPTION
Added lwings2, lwingsj, lwingsja, and lwingsb. Tested all 4 for a short period of time and they seem to work fine. Just copy pasted matching values comparatively from the mame driver. :P

Inspired by request from XtraSmiley --> https://misterfpga.org/viewtopic.php?f=25&t=2464

From the mame driver descriptions --> https://github.com/mamedev/mame/blob/master/src/mame/drivers/lwings.cpp
```
GAME( 1986, lwings2,   lwings,   lwings,    lwings,   lwings_state, empty_init,     ROT90, "Capcom",           "Legendary Wings (US set 2)", MACHINE_SUPPORTS_SAVE )
GAME( 1986, lwingsj,   lwings,   lwings,    lwings,   lwings_state, empty_init,     ROT90, "Capcom",           "Ares no Tsubasa (Japan)", MACHINE_SUPPORTS_SAVE )
GAME( 1986, lwingsja,  lwings,   lwings,    lwings,   lwings_state, empty_init,     ROT90, "Capcom",           "Ares no Tsubasa (Japan, rev. A)", MACHINE_SUPPORTS_SAVE )
GAME( 1986, lwingsb,   lwings,   lwings,    lwingsb,  lwings_state, empty_init,     ROT90, "bootleg",          "Legendary Wings (bootleg)", MACHINE_SUPPORTS_SAVE )
```