### PR TITLE
Adding/Updating Commando MRAs

### DIFF
--- a/mister/commando/releases/Commando.mra
+++ b/mister/commando/releases/Commando.mra
@@ -1,53 +1,86 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
 <misterromdescription>
-	<name>Commando (World)</name>
-	<mameversion>0216</mameversion>
-	<setname>commando</setname>
-	<mratimestamp>201911270000</mratimestamp>
-	<year>1985</year>
-	<manufacturer>Capcom</manufacturer>
-	<category>Army / Fighter</category>
-    <mameversion>0217</mameversion>
-	<rbf alt="jtcom">jtcommando</rbf>
-	<rom index="0" zip="commando.zip" md5="5ba63333cd074858f8303dfbcb885c17" >
-		<part name="cm04.9m"/>
-		<part name="cm03.8m"/>
-		<part name="cm02.9f"/>
-		<part name="vt01.5d"/>
-		<part name="vt11.5a"/>
-		<part name="vt12.6a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt13.7a"/>
-		<part name="vt14.8a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt05.7e"/>
-		<part name="vt06.8e"/>
-		<part name="vt07.9e"/>
-		<part name="vt08.7h"/>
-		<part name="vt09.8h"/>
-		<part name="vt10.9h"/>
-		<part name="vtb1.1d"/>
-		<part name="vtb2.2d"/>
-		<part name="vtb3.3d"/>
-		<part name="vtb4.1h"/>
-		<part name="vtb5.6l"/>
-		<part name="vtb6.6e"/>
-	</rom>
-	<rom index="1"><part>01</part></rom>
-    <switches page_id="1" page_name="Switches" default="FF,CF" base="16">
-        <!-- DSW1 -->
-        <dip name="Starting Area" bits="0,1" ids="6,2,4,0"></dip>
-        <dip name="Lives" bits="2,3" ids="5,2,4,3"></dip>
-        <dip name="Coin B" bits="4,5" ids="4/1,2/1,3/1,1/1"></dip>
-        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"></dip>
-        <!-- DSW2 -->
-        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"></dip>
-        <dip name="Demo Sounds" bits="11" ids="Off,On"></dip>
-        <dip name="Level" bits="12" ids="Hard,Normal"></dip>
-        <dip name="Flip Screen" bits="13" ids="Off,On"></dip>
-        <dip name="Cabinet" bits="14,15" ids="Upright,Upright 2P,Cocktail"></dip>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Commando (World)</name>
+    <setname>commando</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>1985</year>
+    <manufacturer>Capcom</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>World</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="commando.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="cm04.9m" crc="8438b694"/>
+        <part name="cm03.8m" crc="35486542"/>
+        <!-- audiocpu -->
+        <part name="cm02.9f" crc="f9cc4a74"/>
+        <!-- gfx1 -->
+        <part name="vt01.5d" crc="505726e0"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="vt05.7e" crc="79f16e3d"/>
+        <part name="vt06.8e" crc="26fee521"/>
+        <part name="vt07.9e" crc="ca88bdfd"/>
+        <part name="vt08.7h" crc="2019c883"/>
+        <part name="vt09.8h" crc="98703982"/>
+        <part name="vt10.9h" crc="f069d2f8"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Service Mode is accessed by pressing SHOOT1 during region warning screen -->
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
     </switches>
-	<buttons names="Shot,Grenade,Start,Coin,Pause" 
-		default="A,B,R,L,Start"/>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
 </misterromdescription>

--- a/mra/_alternatives/_Commando/Commando (Bootleg Set 1).mra
+++ b/mra/_alternatives/_Commando/Commando (Bootleg Set 1).mra
@@ -1,0 +1,86 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
+<misterromdescription>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Commando (Bootleg Set 1)</name>
+    <setname>commandob</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>1985</year>
+    <manufacturer>Capcom (Bootleg)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>World</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="commando.zip|commandob.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="commandob_04_9m_27256.bin" crc="348a7654"/>
+        <part name="cm03.8m" crc="35486542"/>
+        <!-- audiocpu -->
+        <part name="cm02.9f" crc="f9cc4a74"/>
+        <!-- gfx1 -->
+        <part name="vt01.5d" crc="505726e0"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="vt05.7e" crc="79f16e3d"/>
+        <part name="vt06.8e" crc="26fee521"/>
+        <part name="vt07.9e" crc="ca88bdfd"/>
+        <part name="vt08.7h" crc="2019c883"/>
+        <part name="vt09.8h" crc="98703982"/>
+        <part name="vt10.9h" crc="f069d2f8"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Service Mode is accessed by pressing SHOOT1 during region warning screen -->
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
+    </switches>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
+</misterromdescription>

--- a/mra/_alternatives/_Commando/Commando (Bootleg Set 2).mra
+++ b/mra/_alternatives/_Commando/Commando (Bootleg Set 2).mra
@@ -1,0 +1,86 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
+<misterromdescription>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Commando (Bootleg Set 2)</name>
+    <setname>commandob2</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>1985</year>
+    <manufacturer>Capcom (Bootleg)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>World</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="commando.zip|commandob2.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="10" crc="ab5d1469"/>
+        <part name="11" crc="d1a43ba1"/>
+        <!-- audiocpu -->
+        <part name="8,so02.9f" crc="ca20aca5"/>
+        <!-- gfx1 -->
+        <part name="vt01.5d" crc="505726e0"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="vt05.7e" crc="79f16e3d"/>
+        <part name="vt06.8e" crc="26fee521"/>
+        <part name="vt07.9e" crc="ca88bdfd"/>
+        <part name="vt08.7h" crc="2019c883"/>
+        <part name="vt09.8h" crc="98703982"/>
+        <part name="vt10.9h" crc="f069d2f8"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Service Mode is accessed by pressing SHOOT1 during region warning screen -->
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
+    </switches>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
+</misterromdescription>

--- a/mra/_alternatives/_Commando/Commando (Bootleg Set 3).mra
+++ b/mra/_alternatives/_Commando/Commando (Bootleg Set 3).mra
@@ -1,0 +1,87 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
+<misterromdescription>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Commando (Bootleg Set 3)</name>
+    <setname>commandob3</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>1985</year>
+    <manufacturer>Capcom (Bootleg)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>World</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="commando.zip|commandob3.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="b5.10n" crc="df8f4e9a"/>
+        <part name="b4.9n" crc="aca99905"/>
+        <part name="cm03.8m" crc="35486542"/>
+        <!-- audiocpu -->
+        <part name="b2.9f" crc="f9cc4a74"/>
+        <!-- gfx1 -->
+        <part name="vt01.5d" crc="505726e0"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="vt05.7e" crc="79f16e3d"/>
+        <part name="vt06.8e" crc="26fee521"/>
+        <part name="vt07.9e" crc="ca88bdfd"/>
+        <part name="vt08.7h" crc="2019c883"/>
+        <part name="vt09.8h" crc="98703982"/>
+        <part name="vt10.9h" crc="f069d2f8"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Service Mode is accessed by pressing SHOOT1 during region warning screen -->
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
+    </switches>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
+</misterromdescription>

--- a/mra/_alternatives/_Commando/Commando (US set 1).mra
+++ b/mra/_alternatives/_Commando/Commando (US set 1).mra
@@ -1,78 +1,87 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
 <misterromdescription>
-	<name>Commando (US set 1)</name>
-	<mameversion>0216</mameversion>
-	<setname>commandou</setname>
-	<mratimestamp>201911270000</mratimestamp>
-	<year>1985</year>
-	<manufacturer>Capcom (Data East USA license)</manufacturer>
-	<category>Army / Fighter</category>
-	<rbf>jtcommando</rbf>
-	<rom index="0" zip="commandou.zip" md5="db9d4c87634d826a8146b32a65afd5fe" type="nonmerged">
-		<part name="u4-f.9m"/>
-		<part name="u3-f.8m"/>
-		<part name="cm02.9f"/>
-		<part name="vt01.5d"/>
-		<part name="vt11.5a"/>
-		<part name="vt12.6a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt13.7a"/>
-		<part name="vt14.8a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt05.7e"/>
-		<part name="vt06.8e"/>
-		<part name="vt07.9e"/>
-		<part name="vt08.7h"/>
-		<part name="vt09.8h"/>
-		<part name="vt10.9h"/>
-		<part name="vtb1.1d"/>
-		<part name="vtb2.2d"/>
-		<part name="vtb3.3d"/>
-		<part name="vtb4.1h"/>
-		<part name="vtb5.6l"/>
-		<part name="vtb6.6e"/>
-	</rom>
-	<rom index="0" zip="commando.zip" md5="db9d4c87634d826a8146b32a65afd5fe" type="merged">
-		<part name="commandou/u4-f.9m"/>
-		<part name="commandou/u3-f.8m"/>
-		<part name="cm02.9f"/>
-		<part name="vt01.5d"/>
-		<part name="vt11.5a"/>
-		<part name="vt12.6a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt13.7a"/>
-		<part name="vt14.8a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt05.7e"/>
-		<part name="vt06.8e"/>
-		<part name="vt07.9e"/>
-		<part name="vt08.7h"/>
-		<part name="vt09.8h"/>
-		<part name="vt10.9h"/>
-		<part name="vtb1.1d"/>
-		<part name="vtb2.2d"/>
-		<part name="vtb3.3d"/>
-		<part name="vtb4.1h"/>
-		<part name="vtb5.6l"/>
-		<part name="vtb6.6e"/>
-	</rom>
-		<rom index="1"><part>01</part></rom>
-    <switches page_id="1" page_name="Switches" default="FF,CF" base="16">
-        <!-- DSW1 -->
-        <dip name="Starting Area" bits="0,1" ids="6,2,4,0"></dip>
-        <dip name="Lives" bits="2,3" ids="5,2,4,3"></dip>
-        <dip name="Coin B" bits="4,5" ids="4/1,2/1,3/1,1/1"></dip>
-        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"></dip>
-        <!-- DSW2 -->
-        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"></dip>
-        <dip name="Demo Sounds" bits="11" ids="Off,On"></dip>
-        <dip name="Level" bits="12" ids="Hard,Normal"></dip>
-        <dip name="Flip Screen" bits="13" ids="Off,On"></dip>
-        <dip name="Cabinet" bits="14,15" ids="Upright,Upright 2P,Cocktail"></dip>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Commando (US Set 1)</name>
+    <setname>commandou</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>1985</year>
+    <manufacturer>Capcom (Data East USA license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>USA</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="commando.zip|commandou.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="u4-f.9m" crc="a6118935"/>
+        <part name="u3-f.8m" crc="24f49684"/>
+        <!-- audiocpu -->
+        <part name="cm02.9f" crc="f9cc4a74"/>
+        <!-- gfx1 -->
+        <part name="vt01.5d" crc="505726e0"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="vt05.7e" crc="79f16e3d"/>
+        <part name="vt06.8e" crc="26fee521"/>
+        <part name="vt07.9e" crc="ca88bdfd"/>
+        <part name="vt08.7h" crc="2019c883"/>
+        <part name="vt09.8h" crc="98703982"/>
+        <part name="vt10.9h" crc="f069d2f8"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Demo Sounds enables/disables Service Mode in opposite position -->
+        <dip name="Service Mode" bits="11" ids="On,Off"/>
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
     </switches>
-	<buttons names="Shot,Grenade,Start,Coin,Pause" 
-		default="A,B,R,L,Start"/>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
 </misterromdescription>

--- a/mra/_alternatives/_Commando/Commando (US set 2).mra
+++ b/mra/_alternatives/_Commando/Commando (US set 2).mra
@@ -1,78 +1,86 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
 <misterromdescription>
-	<name>Commando (US set 2)</name>
-	<mameversion>0216</mameversion>
-	<setname>commandou2</setname>
-	<mratimestamp>201911270000</mratimestamp>
-	<year>1985</year>
-	<manufacturer>Capcom (Data East USA license)</manufacturer>
-	<category>Army / Fighter</category>
-	<rbf>jtcommando</rbf>
-	<rom index="0" zip="commandou2.zip" md5="b1b84583f097374a90de68f0f14d2501" type="nonmerged">
-		<part name="uc4.9m"/>
-		<part name="uc3.8m"/>
-		<part name="cd02.9f"/>
-		<part name="vt01.5d"/>
-		<part name="vt11.5a"/>
-		<part name="vt12.6a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt13.7a"/>
-		<part name="vt14.8a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt05.7e"/>
-		<part name="vt06.8e"/>
-		<part name="vt07.9e"/>
-		<part name="vt08.7h"/>
-		<part name="vt09.8h"/>
-		<part name="vt10.9h"/>
-		<part name="vtb-1.1d"/>
-		<part name="vtb-2.2d"/>
-		<part name="vtb-3.3d"/>
-		<part name="vtb-4.1h"/>
-		<part name="vtb-5.6l"/>
-		<part name="vtb-6.6e"/>
-	</rom>
-	<rom index="0" zip="commando.zip" md5="b1b84583f097374a90de68f0f14d2501" type="merged">
-		<part name="commandou2/uc4.9m"/>
-		<part name="commandou2/uc3.8m"/>
-		<part name="cm02.9f"/>
-		<part name="vt01.5d"/>
-		<part name="vt11.5a"/>
-		<part name="vt12.6a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt13.7a"/>
-		<part name="vt14.8a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt05.7e"/>
-		<part name="vt06.8e"/>
-		<part name="vt07.9e"/>
-		<part name="vt08.7h"/>
-		<part name="vt09.8h"/>
-		<part name="vt10.9h"/>
-		<part name="vtb1.1d"/>
-		<part name="vtb2.2d"/>
-		<part name="vtb3.3d"/>
-		<part name="vtb4.1h"/>
-		<part name="vtb5.6l"/>
-		<part name="vtb6.6e"/>
-	</rom>
-		<rom index="1"><part>01</part></rom>
-    <switches page_id="1" page_name="Switches" default="FF,CF" base="16">
-        <!-- DSW1 -->
-        <dip name="Starting Area" bits="0,1" ids="6,2,4,0"></dip>
-        <dip name="Lives" bits="2,3" ids="5,2,4,3"></dip>
-        <dip name="Coin B" bits="4,5" ids="4/1,2/1,3/1,1/1"></dip>
-        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"></dip>
-        <!-- DSW2 -->
-        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"></dip>
-        <dip name="Demo Sounds" bits="11" ids="Off,On"></dip>
-        <dip name="Level" bits="12" ids="Hard,Normal"></dip>
-        <dip name="Flip Screen" bits="13" ids="Off,On"></dip>
-        <dip name="Cabinet" bits="14,15" ids="Upright,Upright 2P,Cocktail"></dip>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Commando (US Set 2)</name>
+    <setname>commandou2</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>1985</year>
+    <manufacturer>Capcom (Data East USA license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>USA</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="commando.zip|commandou2.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="uc4.9m" crc="89ee8e17"/>
+        <part name="uc3.8m" crc="72a1a529"/>
+        <!-- audiocpu -->
+        <part name="cm02.9f" crc="f9cc4a74"/>
+        <!-- gfx1 -->
+        <part name="vt01.5d" crc="505726e0"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="vt05.7e" crc="79f16e3d"/>
+        <part name="vt06.8e" crc="26fee521"/>
+        <part name="vt07.9e" crc="ca88bdfd"/>
+        <part name="vt08.7h" crc="2019c883"/>
+        <part name="vt09.8h" crc="98703982"/>
+        <part name="vt10.9h" crc="f069d2f8"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Service Mode is accessed by pressing SHOOT1 during region warning screen -->
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
     </switches>
-	<buttons names="Shot,Grenade,Start,Coin,Pause" 
-		default="A,B,R,L,Start"/>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
 </misterromdescription>

--- a/mra/_alternatives/_Commando/Commando Deluxe - HBMame.mra
+++ b/mra/_alternatives/_Commando/Commando Deluxe - HBMame.mra
@@ -1,52 +1,86 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
 <misterromdescription>
-	<name>Commando Deluxe - HBMame</name>
-	<mameversion>0216</mameversion>
-	<setname>comdelux</setname>
-	<mratimestamp>201911270000</mratimestamp>
-	<year>2002</year>
-	<manufacturer>Twisty</manufacturer>
-	<category>Army / Fighter</category>
-	<rbf>jtcommando</rbf>
-	<rom index="0" zip="/hbmame/commando.zip" md5="da24fcf65015675db696af1c8eaff8ef" type="merged">
-		<part name="cm04.9m"/>
-		<part name="cm03.8m"/>
-		<part name="cm02.9f"/>
-		<part name="vt01.5d"/>
-		<part name="vt11.5a"/>
-		<part name="vt12.6a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt13.7a"/>
-		<part name="vt14.8a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="comdelux/dx_vt05.7e"/>
-		<part name="vt06.8e"/>
-		<part name="comdelux/dx_vt07.9e"/>
-		<part name="comdelux/dx_vt08.7h"/>
-		<part name="vt09.8h"/>
-		<part name="comdelux/dx_vt10.9h"/>
-		<part name="vtb1.1d"/>
-		<part name="vtb2.2d"/>
-		<part name="vtb3.3d"/>
-		<part name="vtb4.1h"/>
-		<part name="vtb5.6l"/>
-		<part name="vtb6.6e"/>
-	</rom>
-		<rom index="1"><part>01</part></rom>
-    <switches page_id="1" page_name="Switches" default="FF,CF" base="16">
-        <!-- DSW1 -->
-        <dip name="Starting Area" bits="0,1" ids="6,2,4,0"></dip>
-        <dip name="Lives" bits="2,3" ids="5,2,4,3"></dip>
-        <dip name="Coin B" bits="4,5" ids="4/1,2/1,3/1,1/1"></dip>
-        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"></dip>
-        <!-- DSW2 -->
-        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"></dip>
-        <dip name="Demo Sounds" bits="11" ids="Off,On"></dip>
-        <dip name="Level" bits="12" ids="Hard,Normal"></dip>
-        <dip name="Flip Screen" bits="13" ids="Off,On"></dip>
-        <dip name="Cabinet" bits="14,15" ids="Upright,Upright 2P,Cocktail"></dip>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Commando Deluxe - HBMAME</name>
+    <setname>comdelux</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>2002</year>
+    <manufacturer>Capcom (Hack)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>World</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="/hbmame/commando.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="cm04.9m" crc="8438b694"/>
+        <part name="cm03.8m" crc="35486542"/>
+        <!-- audiocpu -->
+        <part name="cm02.9f" crc="f9cc4a74"/>
+        <!-- gfx1 -->
+        <part name="vt01.5d" crc="505726e0"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="dx_vt05.7e" crc="b1839dd4"/>
+        <part name="vt06.8e" crc="26fee521"/>
+        <part name="dx_vt07.9e" crc="4cb1cd67"/>
+        <part name="dx_vt08.7h" crc="42ff8a11"/>
+        <part name="vt09.8h" crc="98703982"/>
+        <part name="dx_vt10.9h" crc="7650a262"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Service Mode is accessed by pressing SHOOT1 during region warning screen -->
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
     </switches>
-	<buttons names="Shot,Grenade,Start,Coin,Pause" 
-		default="A,B,R,L,Start"/>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
 </misterromdescription>

--- a/mra/_alternatives/_Commando/Commando Deluxe Again - HBMame.mra
+++ b/mra/_alternatives/_Commando/Commando Deluxe Again - HBMame.mra
@@ -1,52 +1,86 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
 <misterromdescription>
-	<name>Commando Deluxe Again - HBMame</name>
-	<mameversion>0216</mameversion>
-	<setname>comdlux1</setname>
-	<mratimestamp>201911270000</mratimestamp>
-	<year>1985</year>
-	<manufacturer>Twisty</manufacturer>
-	<category>Army / Fighter</category>
-	<rbf>jtcommando</rbf>
-	<rom index="0" zip="/hbmame/commando.zip" md5="bca4e0cfc8d09094bbb065d285c8370e" type="merged">
-		<part name="cm04.9m"/>
-		<part name="cm03.8m"/>
-		<part name="cm02.9f"/>
-		<part name="vt01.5d"/>
-		<part name="vt11.5a"/>
-		<part name="vt12.6a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt13.7a"/>
-		<part name="vt14.8a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="comdlux1/dx1_vt05.7e"/>
-		<part name="vt06.8e"/>
-		<part name="comdelux/dx_vt07.9e"/>
-		<part name="comdlux1/dx1_vt08.7h"/>
-		<part name="vt09.8h"/>
-		<part name="comdelux/dx_vt10.9h"/>
-		<part name="vtb1.1d"/>
-		<part name="vtb2.2d"/>
-		<part name="vtb3.3d"/>
-		<part name="vtb4.1h"/>
-		<part name="vtb5.6l"/>
-		<part name="vtb6.6e"/>
-	</rom>
-		<rom index="1"><part>01</part></rom>
-    <switches page_id="1" page_name="Switches" default="FF,CF" base="16">
-        <!-- DSW1 -->
-        <dip name="Starting Area" bits="0,1" ids="6,2,4,0"></dip>
-        <dip name="Lives" bits="2,3" ids="5,2,4,3"></dip>
-        <dip name="Coin B" bits="4,5" ids="4/1,2/1,3/1,1/1"></dip>
-        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"></dip>
-        <!-- DSW2 -->
-        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"></dip>
-        <dip name="Demo Sounds" bits="11" ids="Off,On"></dip>
-        <dip name="Level" bits="12" ids="Hard,Normal"></dip>
-        <dip name="Flip Screen" bits="13" ids="Off,On"></dip>
-        <dip name="Cabinet" bits="14,15" ids="Upright,Upright 2P,Cocktail"></dip>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Commando Deluxe Again - HBMAME</name>
+    <setname>comdlux1</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>2002</year>
+    <manufacturer>Capcom (Hack)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>World</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="/hbmame/commando.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="cm04.9m" crc="8438b694"/>
+        <part name="cm03.8m" crc="35486542"/>
+        <!-- audiocpu -->
+        <part name="cm02.9f" crc="f9cc4a74"/>
+        <!-- gfx1 -->
+        <part name="vt01.5d" crc="505726e0"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="dx1_vt05.7e" crc="91865879"/>
+        <part name="vt06.8e" crc="26fee521"/>
+        <part name="dx_vt07.9e" crc="4cb1cd67"/>
+        <part name="dx1_vt08.7h" crc="ba3a06f7"/>
+        <part name="vt09.8h" crc="98703982"/>
+        <part name="dx_vt10.9h" crc="7650a262"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Service Mode is accessed by pressing SHOOT1 during region warning screen -->
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
     </switches>
-	<buttons names="Shot,Grenade,Start,Coin,Pause" 
-		default="A,B,R,L,Start"/>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
 </misterromdescription>

--- a/mra/_alternatives/_Commando/Mercenario (Commando Bootleg).mra
+++ b/mra/_alternatives/_Commando/Mercenario (Commando Bootleg).mra
@@ -1,0 +1,87 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
+<misterromdescription>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Mercenario (Commando Bootleg)</name>
+    <setname>mercenario</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>1985</year>
+    <manufacturer>Capcom (Bootleg)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>World</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="commando.zip|mercenario.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="4ac.bin" crc="59ebf408"/>
+        <part name="4bc.bin" crc="aca99905"/>
+        <part name="b3.8n" crc="f998d08a"/>
+        <!-- audiocpu -->
+        <part name="cm02.9f" crc="f9cc4a74"/>
+        <!-- gfx1 -->
+        <part name="1c.5d" crc="fe3ebe35"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="vt05.7e" crc="79f16e3d"/>
+        <part name="vt06.8e" crc="26fee521"/>
+        <part name="vt07.9e" crc="ca88bdfd"/>
+        <part name="vt08.7h" crc="2019c883"/>
+        <part name="vt09.8h" crc="98703982"/>
+        <part name="vt10.9h" crc="f069d2f8"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Service Mode is accessed by pressing SHOOT1 during region warning screen -->
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
+    </switches>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
+</misterromdescription>

--- a/mra/_alternatives/_Commando/Senjou no Ookami.mra
+++ b/mra/_alternatives/_Commando/Senjou no Ookami.mra
@@ -1,78 +1,86 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
 <misterromdescription>
-	<name>Senjou no Ookami</name>
-	<mameversion>0216</mameversion>
-	<setname>commandoj</setname>
-	<mratimestamp>201911270000</mratimestamp>
-	<year>1985</year>
-	<manufacturer>Capcom</manufacturer>
-	<category>Army / Fighter</category>
-	<rbf>jtcommando</rbf>
-	<rom index="0" zip="commandoj.zip" md5="c5c4e016fc69e6b5df21f169202f2d27" type="nonmerged">
-		<part name="so04.9m"/>
-		<part name="so03.8m"/>
-		<part name="so02.9f"/>
-		<part name="vt01.5d"/>
-		<part name="vt11.5a"/>
-		<part name="vt12.6a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt13.7a"/>
-		<part name="vt14.8a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt05.7e"/>
-		<part name="vt06.8e"/>
-		<part name="vt07.9e"/>
-		<part name="vt08.7h"/>
-		<part name="vt09.8h"/>
-		<part name="vt10.9h"/>
-		<part name="vtb1.1d"/>
-		<part name="vtb2.2d"/>
-		<part name="vtb3.3d"/>
-		<part name="vtb4.1h"/>
-		<part name="vtb5.6l"/>
-		<part name="vtb6.6e"/>
-	</rom>
-	<rom index="0" zip="commando.zip" md5="c5c4e016fc69e6b5df21f169202f2d27" type="merged">
-		<part name="commandoj/so04.9m"/>
-		<part name="commandoj/so03.8m"/>
-		<part name="commandob2/8,so02.9f"/>
-		<part name="vt01.5d"/>
-		<part name="vt11.5a"/>
-		<part name="vt12.6a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt13.7a"/>
-		<part name="vt14.8a"/>
-		<part name="vt15.9a"/>
-		<part name="vt16.10a"/>
-		<part name="vt05.7e"/>
-		<part name="vt06.8e"/>
-		<part name="vt07.9e"/>
-		<part name="vt08.7h"/>
-		<part name="vt09.8h"/>
-		<part name="vt10.9h"/>
-		<part name="vtb1.1d"/>
-		<part name="vtb2.2d"/>
-		<part name="vtb3.3d"/>
-		<part name="vtb4.1h"/>
-		<part name="vtb5.6l"/>
-		<part name="vtb6.6e"/>
-	</rom>
-		<rom index="1"><part>01</part></rom>
-    <switches page_id="1" page_name="Switches" default="FF,CF" base="16">
-        <!-- DSW1 -->
-        <dip name="Starting Area" bits="0,1" ids="6,2,4,0"></dip>
-        <dip name="Lives" bits="2,3" ids="5,2,4,3"></dip>
-        <dip name="Coin B" bits="4,5" ids="4/1,2/1,3/1,1/1"></dip>
-        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"></dip>
-        <!-- DSW2 -->
-        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"></dip>
-        <dip name="Demo Sounds" bits="11" ids="Off,On"></dip>
-        <dip name="Level" bits="12" ids="Hard,Normal"></dip>
-        <dip name="Flip Screen" bits="13" ids="Off,On"></dip>
-        <dip name="Cabinet" bits="14,15" ids="Upright,Upright 2P,Cocktail"></dip>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Senjou no Ookami (Japan)</name>
+    <setname>commandoj</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>1985</year>
+    <manufacturer>Capcom</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>Japan</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="commando.zip|commandoj.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="so04.9m" crc="d3f2bfb3"/>
+        <part name="so03.8m" crc="ed01f472"/>
+        <!-- audiocpu -->
+        <part name="so02.9f" crc="ca20aca5"/>
+        <!-- gfx1 -->
+        <part name="vt01.5d" crc="505726e0"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="vt05.7e" crc="79f16e3d"/>
+        <part name="vt06.8e" crc="26fee521"/>
+        <part name="vt07.9e" crc="ca88bdfd"/>
+        <part name="vt08.7h" crc="2019c883"/>
+        <part name="vt09.8h" crc="98703982"/>
+        <part name="vt10.9h" crc="f069d2f8"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Service Mode is accessed by pressing SHOOT1 during region warning screen -->
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
     </switches>
-	<buttons names="Shot,Grenade,Start,Coin,Pause" 
-		default="A,B,R,L,Start"/>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
 </misterromdescription>

--- a/mra/_alternatives/_Commando/Space Invasion (Bootleg).mra
+++ b/mra/_alternatives/_Commando/Space Invasion (Bootleg).mra
@@ -1,0 +1,86 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
+<misterromdescription>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Space Invasion (Bootleg)</name>
+    <setname>sinvasnb</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>1985</year>
+    <manufacturer>Capcom</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>World</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="commando.zip|sinvasn.zip|sinvasnb.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="u4" crc="834ba0de"/>
+        <part name="u3" crc="07e4ee3a"/>
+        <!-- audiocpu -->
+        <part name="u2" crc="cbf8c40e"/>
+        <!-- gfx1 -->
+        <part name="u1" crc="f477e13a"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="u5" crc="2a97c933"/>
+        <part name="vt06.e8" crc="26fee521"/>
+        <part name="vt07.e9" crc="ca88bdfd"/>
+        <part name="u8" crc="d6b4aa2e"/>
+        <part name="vt09.h8" crc="98703982"/>
+        <part name="vt10.h9" crc="f069d2f8"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Service Mode is accessed by pressing SHOOT1 during region warning screen -->
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
+    </switches>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
+</misterromdescription>

--- a/mra/_alternatives/_Commando/Space Invasion (Bootleg).mra
+++ b/mra/_alternatives/_Commando/Space Invasion (Bootleg).mra
@@ -25,7 +25,7 @@
     <setname>sinvasnb</setname>
     <rbf alt="jtcom">jtcommando</rbf>
     <year>1985</year>
-    <manufacturer>Capcom</manufacturer>
+    <manufacturer>Capcom (Bootleg)</manufacturer>
     <players>2</players>
     <joystick>8-way</joystick>
     <rotation>Vertical</rotation>

--- a/mra/_alternatives/_Commando/Space Invasion (Bootleg).mra
+++ b/mra/_alternatives/_Commando/Space Invasion (Bootleg).mra
@@ -29,7 +29,7 @@
     <players>2</players>
     <joystick>8-way</joystick>
     <rotation>Vertical</rotation>
-    <region>World</region>
+    <region>Europe</region>
     <category>Shooter / Walking</category>
     <mameversion>0230</mameversion>
     <mratimestamp>20210418</mratimestamp>

--- a/mra/_alternatives/_Commando/Space Invasion (Europe).mra
+++ b/mra/_alternatives/_Commando/Space Invasion (Europe).mra
@@ -1,0 +1,86 @@
+<!--          FPGA compatible core for Capcom arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2021. Please support the author
+              Patreon: https://patreon.com/topapate
+              Paypal:  https://paypal.me/topapate
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with legally
+              obtained ROM dumps or with compatible homebrew software.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+-->
+
+<misterromdescription>
+    <about author="jotego" webpage="https://patreon.com/topapate" source="https://github.com/jotego" twitter="@topapate"/>
+    <name>Space Invasion (Europe)</name>
+    <setname>sinvasn</setname>
+    <rbf alt="jtcom">jtcommando</rbf>
+    <year>1985</year>
+    <manufacturer>Capcom</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>Vertical</rotation>
+    <region>World</region>
+    <category>Shooter / Walking</category>
+    <mameversion>0230</mameversion>
+    <mratimestamp>20210418</mratimestamp>
+    <rom index="0" zip="commando.zip|sinvasn.zip" type="merged|nonmerged|split" md5="none">
+        <!-- maincpu -->
+        <part name="sp04.9m" crc="33f9601e"/>
+        <part name="sp03.8m" crc="c7fb43b3"/>
+        <!-- audiocpu -->
+        <part name="u2.9f" crc="cbf8c40e"/>
+        <!-- gfx1 -->
+        <part name="u1.5d" crc="f477e13a"/>
+        <!-- gfx2 -->
+        <part name="vt11.5a" crc="7b2e1b48"/>
+        <part name="vt12.6a" crc="81b417d3"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <part name="vt13.7a" crc="5612dbd2"/>
+        <part name="vt14.8a" crc="2b2dee36"/>
+        <part name="vt15.9a" crc="de70babf"/>
+        <part name="vt16.10a" crc="14178237"/>
+        <!-- gfx3 -->
+        <part name="u5.e7" crc="2a97c933"/>
+        <part name="sp06.e8" crc="d7887212"/>
+        <part name="sp07.e9" crc="9abe7a20"/>
+        <part name="u8.h7" crc="d6b4aa2e"/>
+        <part name="sp09.h8" crc="3985b318"/>
+        <part name="sp10.h9" crc="3c131b0f"/>
+        <!-- proms -->
+        <part name="vtb1.1d" crc="3aba15a1"/>
+        <part name="vtb2.2d" crc="88865754"/>
+        <part name="vtb3.3d" crc="4c14c3f6"/>
+        <part name="vtb4.1h" crc="b388c246"/>
+        <part name="vtb5.6l" crc="712ac508"/>
+        <part name="vtb6.6e" crc="0eaf5158"/>
+    </rom>
+    <rom index="1">
+        <part>01</part>
+    </rom>
+    <switches page_id="1" page_name="DIP Switches" default="FF,3F" base="16">
+        <!-- SW1 -->
+        <dip name="Starting Area" bits="0,1" ids="7 (Desert 2),3 (Desert 1),5 (Forest 2),1 (Forest 1)"/>
+        <dip name="Lives" bits="2,3" ids="5,2,4,3"/>
+        <dip name="Coin B" bits="4,5" ids="2/1,1/2,1/3,1/1"/>
+        <dip name="Coin A" bits="6,7" ids="2/1,1/2,1/3,1/1"/>
+        <!-- SW2 -->
+        <dip name="Bonus Life" bits="8,10" ids="None,20K 70K+,30K 80K+,10K 60K+,40K 100K+,20K 60K+,30K 70K+,10K 50K+"/>
+        <dip name="Demo Sounds" bits="11" ids="Off,On"/>
+        <!-- Service Mode is accessed by pressing SHOOT1 during region warning screen -->
+        <dip name="Difficulty" bits="12" ids="Difficult,Normal"/>
+        <dip name="Flip Screen" bits="13" ids="Off,On"/>
+        <dip name="Cabinet" bits="14,15" ids="Upright 1P,Upright 2P,Cocktail"/>
+    </switches>
+    <buttons names="Machine Gun,Hand Grenade,Start,Coin,Pause" default="A,B,R,L,Start" count="2"/>
+</misterromdescription>

--- a/mra/_alternatives/_Commando/Space Invasion (Europe).mra
+++ b/mra/_alternatives/_Commando/Space Invasion (Europe).mra
@@ -29,7 +29,7 @@
     <players>2</players>
     <joystick>8-way</joystick>
     <rotation>Vertical</rotation>
-    <region>World</region>
+    <region>Europe</region>
     <category>Shooter / Walking</category>
     <mameversion>0230</mameversion>
     <mratimestamp>20210418</mratimestamp>


### PR DESCRIPTION
- Adding bootlegs
- Updated and expanded metadata
- Removed duplicate `<mameversion>` tags
- Consolidated ROM information based on MAME 0.230 ROM set (current)
- Added ROM descriptions as well as CRCs to allow merged, non-merged, and split ROM set use
- Updated DIP switch information and corrected ordering of options, verified with Service Mode
- Added information regarding accessing Service Mode for different sets
- Enabled Flip Screen as default (no effect in Service Mode)
- Updated button names