### PR TITLE
Update Tetris (Set 3 Bootleg, Japan, S16A) [No Protection].mra

### DIFF
--- a/mra/_alternatives/_Tetris/Tetris (Set 3 Bootleg, Japan, S16A) [No Protection].mra
+++ b/mra/_alternatives/_Tetris/Tetris (Set 3 Bootleg, Japan, S16A) [No Protection].mra
@@ -75,7 +75,7 @@
         <part repeat="0x400"> FF</part>
         <!-- Total 0x184400 bytes - 1553 kBytes -->
     </rom>
-    <rom index="16" zip="beta.zip" md5="None">
+    <rom index="16" zip="jtbeta.zip" md5="None">
         <part name="beta.bin"/>
     </rom>
     <rom index="1">


### PR DESCRIPTION
Update to use the correct jtbeta file