### PR TITLE
Renames the multi-zip workflow & makes a small change so it'll run

### DIFF
--- a/.github/workflows/pocket_zips.yml
+++ b/.github/workflows/pocket_zips.yml
@@ -1,4 +1,4 @@
-name: Pocket ZIP files
+name: Pocket per core ZIP files
 
 on:
   push:

--- a/pocket/raw/Cores/jotego.jtgng/core.json
+++ b/pocket/raw/Cores/jotego.jtgng/core.json
@@ -9,8 +9,8 @@
 			"description": "Arcade hardware",
 			"author": "jotego",
 			"url": "https://patreon.com/jotego",
-			"version": "noversion",
-			"date_release": "2022-12-07"
+			"date_release": "2022-12-07",
+			"version": "noversion"
 		},
 		"framework": {
 			"target_product": "Analogue Pocket",


### PR DESCRIPTION
- Didn't notice that I'd not changed the name of the multi-core zip workflow, which would have been confusing
- Also makes a small formatting change to a core file under `pocket/raw` so the multi-zip workflow should run