### PR TITLE
fixed gng core filename

### DIFF
--- a/pocket/raw/Cores/jotego.jtgng/core.json
+++ b/pocket/raw/Cores/jotego.jtgng/core.json
@@ -30,7 +30,7 @@
 			{
 				"name": "jtgng",
 				"id": 0,
-				"filename": "jtdd2.rbf_r"
+				"filename": "jtgng.rbf_r"
 			}
 		]
 	}


### PR DESCRIPTION
core.json in jtgng was pointing at the wrong filename