### PR TITLE
Removing jtpremium trigger

### DIFF
--- a/.github/workflows/trigger_databases.yml
+++ b/.github/workflows/trigger_databases.yml
@@ -20,11 +20,3 @@ jobs:
         repo: jotego/jtcores_mister
         ref: refs/heads/main
         token: ${{ secrets.JTBIN_UPDATER }}
-
-    - name: Trigger jtpremium
-      uses: benc-uk/workflow-dispatch@v1
-      with:
-        workflow: update jtcores
-        repo: jotego/jtpremium
-        ref: refs/heads/main
-        token: ${{ secrets.JTBIN_UPDATER }}


### PR DESCRIPTION
No point in updating jtpremium content anymore, since users now only use jtcores_mister, which can be configured to also download premium cores on demand (through Update All, by editing downloader.ini manually, or by downloading the main branch zip).

We should be able to delete jtpremium repository by the end of the year, since now is redundant.