### PR TITLE
include Saves directory in pocket zips

### DIFF
--- a/.github/workflows/pocket_zips.yml
+++ b/.github/workflows/pocket_zips.yml
@@ -53,6 +53,7 @@ jobs:
           echo "Assets/${shortname}" >> file_list.txt
           echo "Platforms/${shortname}.json" >> file_list.txt
           echo "Platforms/_images/${shortname}.bin" >> file_list.txt
+          echo "Saves/${shortname}" >> file_list.txt
       - name: echo files
         run: cat file_list.txt
       - name: get version


### PR DESCRIPTION
the release zips built for analogue pocket aren't including the Saves directory, since it wasn't needed til this most recent week when pre-configured .sav files were packaged in a few core releases