### PR TITLE
Update data.json for NGP Analogue Pocket core

### DIFF
--- a/pocket/raw/Cores/jotego.jtngp/data.json
+++ b/pocket/raw/Cores/jotego.jtngp/data.json
@@ -8,7 +8,8 @@
 				"required": true,
 				"parameters": "0x09",
 				"extensions": [
-					"ngp"
+					"ngp",
+					"ngc"
 				],
 				"address": "0x00000000",
 				"nonvolatile": false


### PR DESCRIPTION
Added extension "ngc" so that backwards-compatible NGPC ROMs will be viewable from within the NGP Pocket core file browser. Based on my testing, far more of these colour games are compatible with the monochrome core than on the MAME published list. Here is a source for monochrome compatibility of what was designed to work: https://www.neo-geo.com/pocket/

Some may not load correctly but this at least gives the user the freedom to try. If this needs to be explained in docs then that could be done.